### PR TITLE
OPUSVIER-4112

### DIFF
--- a/development/application.md
+++ b/development/application.md
@@ -3,6 +3,36 @@ title: Applikation
 weight: 60
 ---
 
+# Zugriff auf Boolesche Konfigurationsparameter
+
+Der Zugriff auf Boolesche Konfigurationsparameter (über `Zend_Config`) sollte
+folgendermaßen umgesetzt werden (hier am Beispiel des Konfigurationsparameters
+`foo.bar`):
+
+```php
+$config = Zend_Registry::get('Zend_Config');
+$boolVal = isset($config->foo->bar) && filter_var($config->foo->bar, FILTER_VALIDATE_BOOLEAN);
+```
+
+Diese Art des Auslesen garantiert, dass in `$boolVal` tatsächlich ein boolescher
+Wert (`TRUE` oder `FALSE`) steht. Ist der Parameter `foo.bar` in der Konfiguration
+gar nicht vorhanden, so liefert `$boolVal` ebenfalls `FALSE`.
+
+Innerhalb von Konfigurationsdateien (`ini`-Dateien) werden die folgenden Werte
+auf den Wahrheitswert `TRUE` abgebildet:
+
+```
+1
+true
+'1'
+'true'
+'on'
+'yes'
+```
+
+Alle anderen Werte werden auf `FALSE` abgebildet.
+
+
 # Unit Tests
 
 ## Setup

--- a/development/codingstyle.md
+++ b/development/codingstyle.md
@@ -5,17 +5,17 @@ weight: 50
 
 # Coding Style
 
-OPUS 4 ist zum größten Teil in PHP geschrieben. Der Code folgt den Prinzipien der Objekt-Orientierten 
+OPUS 4 ist zum größten Teil in PHP geschrieben. Der Code folgt den Prinzipien der Objekt-Orientierten
 Programmierung (OOP).  
 
-OPUS 4 richtet sich im Allgemeinen nach dem Coding Style vom Zend Framework 1 und neuer. 
+OPUS 4 richtet sich im Allgemeinen nach dem Coding Style vom Zend Framework 1 und neuer.
 
 * [Zend Framework 1.12 Coding Style][ZF1CS]
 * [Zend Framework 2.4 Coding Standard for PHP][ZF2CS]
 {: class="navlist" }
 
 In einigen Punkten weicht der OPUS 4 Source Code von dem auf den Seiten oben beschriebenen Stil ab. Im folgenden
-werden die wichtigsten Punkte hervorgehoben. Der Coding Style soll in der Regel durch technische Maßnahmen sicher 
+werden die wichtigsten Punkte hervorgehoben. Der Coding Style soll in der Regel durch technische Maßnahmen sicher
 gestellt werden.  
 
 ## Allgemeines
@@ -28,16 +28,16 @@ gestellt werden.
 
 ## Namen von Variablen und Klassen
 
-Variablen und Arrays beginnen immer mit einem kleinen Buchstaben. Für jedes neue Wort wird der erste Buchstabe groß 
-geschrieben, zum Beispiel `$halloWelt`. Wir verwenden keinen Präfix '_' für Variablen, die **protected** oder 
+Variablen und Arrays beginnen immer mit einem kleinen Buchstaben. Für jedes neue Wort wird der erste Buchstabe groß
+geschrieben, zum Beispiel `$halloWelt`. Wir verwenden keinen Präfix `'_'` für Variablen, die **protected** oder
 **private** sind.
 
 Das selbe gilt für Funktionen. In Test-Funktionen ist das erste Wort immer z.B. `testHalloWelt()`.
 
 Klassen beginnen mit einem Großbuchstaben. Außerdem steht vor der Klasse der Pfad der Klasse, der durch
-einen Unterstrich getrennt wird. 
+einen Unterstrich getrennt wird.
 
-In neueren Paketen wie **opus4-common** verwenden wir bereits Namespaces. Das Framework und die Application 
+In neueren Paketen wie **opus4-common** verwenden wir bereits Namespaces. Das Framework und die Application
 verwenden noch ein älteres Namenschema wie es in Zend Framework 1 verwendet wird. In der Application sind Klassen
 in der Regel entweder Teil eines Modules oder der Library.  
 
@@ -45,7 +45,7 @@ in der Regel entweder Teil eines Modules oder der Library.
 | ------ | ----- |
 | `Application_Controller_ActionCRUD` | library/Application/Controller/ActionCRUD.php |
 | `Admin_Model_EnrichmentKeys` | modules/admin/models/EnrichmentKeys.php |
-    
+
 ## Arrays
 
 Für Arrays verwenden wir die Kurzschreibweise, also `[]`. Die alte Form, `array()` wird nicht mehr verwendet. Muss
@@ -63,30 +63,30 @@ $two = [
 
 In der Dokumentation sollte nicht nur das stehen, was man sowieso schon im Code sieht. Am wichtigsten ist es
 die Absichten festzuhalten, so dass später bei Problemen ein Abgleich zwischen dem was ein Stück Code tun soll
-und was es wirklich tut vorgenommen werden kann. 
+und was es wirklich tut vorgenommen werden kann.
 
 Darüber hinaus ist es wichtig zu dokumentieren, wenn Kompromisse eingegangen werden und warum. Zusammenhänge,
 die sich nicht direkt aus dem Code erschließen und wichtig für das Verständnis eines Entwicklers sind sollten
-dokumentiert werden. 
+dokumentiert werden.
 
 Es geht bei der Dokumenation nicht darum, irgendwelche Minimalanforderungen zu erfüllen. Man sollte sich immer
-fragen, was der neue Entwickler, der morgen anfangt braucht, um schnell einsteigen zu können. Was braucht ich, 
+fragen, was der neue Entwickler, der morgen anfangt braucht, um schnell einsteigen zu können. Was braucht ich,
 wenn ich mir den Code in zwei Jahren anschaue?  
 
-Jede Funktion und jede Klasse sollte einen Dokumentationsblock haben. Die drei wichtigsten Bestandteile sind 
-die Beschreibung der Funktionalität, die Parameter und der Rückgabewert. Die Beschreibung sollte in einem 
-kurzen Satz in einer Zeile erfolgen. Danach können weiter Erläuterungen über mehrere Zeilen hinweg geschrieben 
+Jede Funktion und jede Klasse sollte einen Dokumentationsblock haben. Die drei wichtigsten Bestandteile sind
+die Beschreibung der Funktionalität, die Parameter und der Rückgabewert. Die Beschreibung sollte in einem
+kurzen Satz in einer Zeile erfolgen. Danach können weiter Erläuterungen über mehrere Zeilen hinweg geschrieben
 werden.
 
 {% highlight php %}
 /**
  * Kurze Beschreibung der Funktion.
  *
- * Ausführlichere Erläuterungen zur Funktion. 
+ * Ausführlichere Erläuterungen zur Funktion.
  *
  * @param  
- * @param 
- * @return 
+ * @param
+ * @return
  */
 {% endhighlight %}
 
@@ -94,13 +94,13 @@ werden.
 
 Nicht für jede Kleinigkeit lohnt sich ein neues Ticket. Manchmal müssen Kompromisse gemacht werden, bei denen klar
 ist, dass später weitere Änderungen sinnvoll werden. Erkenntnisse sollten mit `@TODO` oder `@FIXME` direkt im Code
-festgehalten werden, damit diese Informationen nicht verloren gehen und später schnell aufgegriffen werden können. 
+festgehalten werden, damit diese Informationen nicht verloren gehen und später schnell aufgegriffen werden können.
 
 ## Header
 
 Alle OPUS 4-Dateien bekommen einen Lizenz-Header wie den folgenden. In manchen Dateien müssen weitere Header und
-Lizenzen von anderen Projekten berücksichtigt werden. Die Metadaten müssen für jede Datei angepasst werden, 
-insbesondere `@category`, `@package`, `@author` und `@copyright`. 
+Lizenzen von anderen Projekten berücksichtigt werden. Die Metadaten müssen für jede Datei angepasst werden,
+insbesondere `@category`, `@package`, `@author` und `@copyright`.
 
 {% highlight php %}
 /**
@@ -139,21 +139,21 @@ insbesondere `@category`, `@package`, `@author` und `@copyright`.
 # PHP CodeSniffer
 
 In den `composer.json`-Dateien sind Skripte definiert, um den Coding Style automatisch zu überprüfen. Dabei wird `phpcs`
-verwendet, dass in der Datei `phpcs.xml` konfiguriert wird. Mit Composer kann man die Prüfungen wie folgt ausführen. 
+verwendet, dass in der Datei `phpcs.xml` konfiguriert wird. Mit Composer kann man die Prüfungen wie folgt ausführen.
 
     $ composer cs-check
-    
+
 Mit folgendem Kommando wird ein Report generiert und in `build/checkstyle.xml` gespeichert.
 
-    $ composer cs-report 
+    $ composer cs-report
 
 Nicht alle aktuellen Dateien in OPUS 4 entsprechen bereits dem Standard.
-   
+
 <p class="note" markdown="1">
-Für neuere Pakete, wie [opus4-common][OPUS4COMMON] muss die Prüfung des Coding Styles ohne Meldungen durchlaufen. 
-Beim [framework][FRAMEWORK] und der [application][APPLICATION] gibt es noch alten Code, der noch nicht angepasst wurde. 
-Dort werden zur Zeit noch viele Verletzungen des Coding Styles gemeldet. 
-Hier sollten vorerst nur einzelne Dateien geprüft werden. Neuer oder veränderter Code muss den Vorgaben entsprechen. 
+Für neuere Pakete, wie [opus4-common][OPUS4COMMON] muss die Prüfung des Coding Styles ohne Meldungen durchlaufen.
+Beim [framework][FRAMEWORK] und der [application][APPLICATION] gibt es noch alten Code, der noch nicht angepasst wurde.
+Dort werden zur Zeit noch viele Verletzungen des Coding Styles gemeldet.
+Hier sollten vorerst nur einzelne Dateien geprüft werden. Neuer oder veränderter Code muss den Vorgaben entsprechen.
 </p>
 
 # Beispiel
@@ -166,7 +166,7 @@ class Foo
 {
 
     const KONSTANTE = 'beispiel';
-    
+
     private $counter = 0;
 
     /**

--- a/development/testing.md
+++ b/development/testing.md
@@ -4,31 +4,31 @@ title: Unit-Tests
 
 # Unit-Tests
 
-Die Unit Tests befinden sich im Verzeichnis `tests`. Um sie auszuführen kann man z.B. 
+Die Unit Tests befinden sich im Verzeichnis `tests`. Um sie auszuführen kann man z.B.
 folgende Kommandos verwenden.
 
     $ cd tests
     $ ../vendor/bin/phpunit . | tee testresult.txt
-    
+
 Mit "`../vendor/bin/phpunit .`" wird die durch Composer installierte Version von PHPUnit
-verwendet und sämtliche Tests ausgeführt. Durch "`| tee testresult.txt`" werden die Ausgaben während des Tests 
+verwendet und sämtliche Tests ausgeführt. Durch "`| tee testresult.txt`" werden die Ausgaben während des Tests
 zusätzlich in die Datei `testresult.txt` geschrieben.
 
-Folgende Zeile würde nur die Tests für `Opus_Document` ausführen. 
+Folgende Zeile würde nur die Tests für `Opus_Document` ausführen.
 
     $ ../vendor/bin/phpunit Opus/DocumentTest    
-    
-Am Ende des Testdurchlaufs werden die Tests mit Fehlern aufgelistet. Mit der Option `--debug` 
+
+Am Ende des Testdurchlaufs werden die Tests mit Fehlern aufgelistet. Mit der Option `--debug`
 werden bereits während der Ausführung die Namen der Tests aufgelistet.
 
     $ ../vendor/bin/phpunit --debug .     
 
 Die Unit-Tests lassen sich auch mit `ant` ausführen. Im Root-Verzeichnis von OPUS 4 liegt
 die Datei `build.xml`, die verschiedene Targets für die Ausführung definiert. Mit folgendem
-Kommando lassen sich alle Tests ausführen. 
+Kommando lassen sich alle Tests ausführen.
 
     $ ant phpunit-fast     
-    
+
 Dabei werden die Zwischenergebnisse immer erst am Ende einer Zeile ausgegeben. Ant wird auch
 vom CI-System für die Ausführung der Tests verwendet.
 
@@ -40,45 +40,58 @@ Test müssen daher die Testdaten vorher zurückgesetzt werden. Aufgrund des Zeit
 dies nicht automatisch vor jedem Test.
 
 Mit folgendem Kommando werden die Datenbank und die Volltextdateien zurückgesetzt und eine
-neue Indizierung durchgeführt. 
+neue Indizierung durchgeführt.
 
     $ ant reset-testdata
-    
+
 Um die ausführlichen Information zum Kopieren der Testdateien zu sehen, kann `-Dverbose=1`
 verwendet werden.
 
     $ ant reset-testdata -Dverbose=1    
 
+# Manipulation der `Zend_Config` innerhalb von Tests
+
+Bei der Manipulation oder dem Hinzufügen von Werten in der `Zend_Config` sollte
+darauf geachtet werden, dass beim Setzen von Booleschen Werten ausschließlich
+die Konstanten `CONFIG_VALUE_TRUE` bzw. `CONFIG_VALUE_FALSE` aus der Klasse
+`ControllerTestCase` verwendet werden. Die Konstanten repräsentieren die Werte,
+die Zend beim Auslesen von booleschen Werten aus `ini`-Dateien setzt. In ZF1
+ist das `'1'` für `true` und `''` (Leerstring) für `false`.
+
+Ein Zurücksetzen von Änderungen in `Zend_Config` am Ende eines Tests ist **nicht**
+erforderlich. Die `Zend_Config` wird bei jedem Test neu geladen, so dass zuvor
+geänderte oder neu hinzugefügte Werte nicht mehr vorhanden sind.
+
 # XHTML/XML-Schema-Dateien lokal cachen
 
 Während der Tests werden die Ausgaben von OPUS 4 unter anderem auf korrektes XHTML geprüft.
-Für das XHTML-Schema wird normalerweise auf Ressourcen auf den Servern von 
-[www.w3.org](www.w3.org) 
+Für das XHTML-Schema wird normalerweise auf Ressourcen auf den Servern von
+[www.w3.org](www.w3.org)
 zugegriffen. Der Zugriff auf diese Server ist gedrosselt, so dass Anfragen manchmal sehr
-lange dauern. Manche Unit-Tests benötigen dadurch Minuten anstelle von Sekunden. Um die 
+lange dauern. Manche Unit-Tests benötigen dadurch Minuten anstelle von Sekunden. Um die
 Tests zu beschleunigen kann die Verwendung lokaler Kopien der Schema-Dateien konfiguriert
 werden.
 
 Die notwendigen XML-Schema-Dateien befinden sich in folgendem Verzeichnis:
 
     tests/resources
-    
+
 und sind in eine XML-Katalog-Datei aufgelistet:
 
     tests/resources/opus4-catalog.xml
-    
+
 Damit der XML-Katalog verwendet wird muss die Environmentvariable `XML_CATALOG_FILES`
-gesetzt werden, z.B. in der `.bashrc` Datei. 
+gesetzt werden, z.B. in der `.bashrc` Datei.
 
 ``` bash
 export XML_CATALOG_FILES=~/projects/opus4/tests/resources/opus4-catalog.xml
 ```
-    
-Sollen die Unit-Tests in einer IDE ausgeführt werden, sollte die Variable auch dort für 
+
+Sollen die Unit-Tests in einer IDE ausgeführt werden, sollte die Variable auch dort für
 die Ausführung von PHPUnit konfiguriert werden. Wie das genau passiert ist für jede IDE
 etwas anders.
 
-In IntelliJ IDEA kann die Konfiguration der Variable unter `Run->Edit Configurations...` 
+In IntelliJ IDEA kann die Konfiguration der Variable unter `Run->Edit Configurations...`
 für die PHPUnit-Default-Einstellungen erfolgen.
 
 * [Weitere Informationen zu XML-Catalogs](http://xmlsoft.org/catalog.html)
@@ -88,7 +101,7 @@ für die PHPUnit-Default-Einstellungen erfolgen.
 
 Die Code-Coverage gibt an wieviel vom Code durch die Tests abgedeckt wird. Insbesondere
 die Controller-Tests sind aber keine Unit Tests, sondern Integrationstest. Mindestens für
-die Tests sollte die Coverage eingeschränkt werden. Dafür kann `@covers` verwendet werden. 
+die Tests sollte die Coverage eingeschränkt werden. Dafür kann `@covers` verwendet werden.
 
 ``` php
 /**
@@ -98,8 +111,8 @@ die Tests sollte die Coverage eingeschränkt werden. Dafür kann `@covers` verwe
  * @covers IndexController
  */
 ```
-     
-Dadurch wird nur die Tests erzeugte Coverage für den IndexController berücksichtigt und 
+
+Dadurch wird nur die Tests erzeugte Coverage für den IndexController berücksichtigt und
 nicht für die Klassen, die bei der Ausführung evtl. auch noch berührt werden. Es gibt
 noch weitere Wege, um die Coverage einzuschränken und ein ehrlicheres Bild der Abdeckung
 zu bekommen. Für genauere Information bitte die PHPUnit Dokumentation hinzuziehen.     
@@ -110,7 +123,7 @@ Die Geschwindigkeit der Tests wird unter anderem durch den Speicherverbrauch bee
 Leider ist es schwierig nach jedem Tests den Speicher wieder komplett aufzuräumen. Dadurch
 steigt der Speicherverbrauch mit jedem Test etwas an. Bei 3500+ Tests für die Application
 kommt dabei einiges zusammen und die Laufzeit verlängert sich beträchtlich. Um diesen Effekt
-abzumildern wurden einige Massnahmen getroffen. 
+abzumildern wurden einige Massnahmen getroffen.
 
 ## Tests in Blöcken
 
@@ -126,24 +139,24 @@ sind als Testsuites in `tests/phpunit.xml` definiert.
 
 ## Selektives Laden der Ressourcen
 
-Jede Testklasse sollte nur die Ressourcen laden die notwendig sind. Folgendes Beispiel 
-sorgt dafür, dass die Datenbank und die Übersetzungen verfügbar sind. Insbesondere die 
+Jede Testklasse sollte nur die Ressourcen laden die notwendig sind. Folgendes Beispiel
+sorgt dafür, dass die Datenbank und die Übersetzungen verfügbar sind. Insbesondere die
 Übersetzungen beeinflussen die Laufzeit von Tests beträchtlich.  
 
 ``` php
 protected $additionalResources = ['database', 'translation'];
-``` 
+```
 
 Die verfügbaren Ressourcen entsprechen, den `_initXXX`-Funktionen im Bootstrap von OPUS, also
-in `Application_Bootstrap` und `Opus_Bootstrap_Base`. Die folgenden Ressourcen werden 
+in `Application_Bootstrap` und `Opus_Bootstrap_Base`. Die folgenden Ressourcen werden
 automatisch geladen.
 
 * configuration
 * logging
 
-Gibt man für `$additionalResources` den Wert `all` an wird der gesamte Bootstrap ausgeführt. 
+Gibt man für `$additionalResources` den Wert `all` an wird der gesamte Bootstrap ausgeführt.
 
-Mit folgender Option kann man dafür sorgen, dass die Konfiguration in einem Test manipulierbar 
+Mit folgender Option kann man dafür sorgen, dass die Konfiguration in einem Test manipulierbar
 ist.
 
 ``` php
@@ -152,10 +165,10 @@ protected $configModifiable = true;
 
 ## Memory-Leak reduzieren
 
-Bei den Tests wird das Übersetzungsobjekt, `Application_Translate`, wiederverwendet. 
-Dadurch sinkt der Speicherverbrauch beträchtlich. Für den produktiven Betrieb hat das keine 
-Auswirkungen, da dort nach jedem Request, der Speicher wieder freigegeben wird. 
+Bei den Tests wird das Übersetzungsobjekt, `Application_Translate`, wiederverwendet.
+Dadurch sinkt der Speicherverbrauch beträchtlich. Für den produktiven Betrieb hat das keine
+Auswirkungen, da dort nach jedem Request, der Speicher wieder freigegeben wird.
 
-Es gibt noch weitere Objekte durch die mit jedem Test der Speicherverbrauch steigt, unter 
+Es gibt noch weitere Objekte durch die mit jedem Test der Speicherverbrauch steigt, unter
 anderem vermutlich `Zend_Acl`. Momentan haben wir den Verbrauch aber auf etwa 300 MB gesenkt
 und die Laufzeit mit Travis beträgt etwa 27 Minuten. Das ist für den Augenblick gut genug.


### PR DESCRIPTION
Scheinbar hat der Atom-Editor automatisch beim Speichern abschließende Whitespaces entfernt. Bitte beim Code Review Whitespace-Changes ignorieren, damit Du die echten Änderungen einfach erkennst.